### PR TITLE
Allow skipping pages on comics

### DIFF
--- a/fetcher.py
+++ b/fetcher.py
@@ -45,35 +45,36 @@ def fetchcomic(comic, download_directory):
 		#get the current pages contents
 		pagefeed = fetchpageretry(current_page_url)
 		
-		#find and download the image from said page
-		img_url = cracker.findurl(pagefeed, comicdef["imageregex"], comicdef["rootcomicdir"])
-		if img_url == None:
-			print("No image found")
-			break
+		if current_page_url not in comicdef["skip"].split():
+		    #find and download the image from said page
+		    img_url = cracker.findurl(pagefeed, comicdef["imageregex"], comicdef["rootcomicdir"])
+		    if img_url == None:
+			    print("No image found on %s" % current_page_url)
+			    break
 
-		downloadcomicdir = download_directory + "/" + comicdef["comicname"] + "/"
-		#if comicdef["autonumber"] != "#autonumber":
-		downloadfilename = '0'*(8-len(str(autocount)))+ str(autocount) +"."+ img_url.split(".")[-1]
-		#elif comicdef["useurlflag"] != "#useurlflag":
-		#	downloadfilename = current_page_url.split("/")[-1]
-		#	try:
-		#		downloadfilename = downloadfilename + "." +  img_url.split(".")[-1]
-		#	except:
-		#		pass
-		#	try:
-		#		downloadfilename = downloadfilename.split("=")[-1]
-		#	except:
-		#		pass
-		#else:
-		#	downloadfilename = img_url.split("/")[-1]
-		
-		#urllib.request.urlretrieve(img_url, downloadcomicdir + downloadfilename)
-		print("Downloading " + img_url + " as " + downloadfilename)
-		filetosave = open(downloadcomicdir + downloadfilename, "wb")
-		
-		filetosave.write(requests.get(img_url, headers=notarobotheader).content)
-		filetosave.close()
-	
+		    downloadcomicdir = download_directory + "/" + comicdef["comicname"] + "/"
+		    #if comicdef["autonumber"] != "#autonumber":
+		    downloadfilename = '0'*(8-len(str(autocount)))+ str(autocount) +"."+ img_url.split(".")[-1]
+		    #elif comicdef["useurlflag"] != "#useurlflag":
+		    #	downloadfilename = current_page_url.split("/")[-1]
+		    #	try:
+		    #		downloadfilename = downloadfilename + "." +  img_url.split(".")[-1]
+		    #	except:
+		    #		pass
+		    #	try:
+		    #		downloadfilename = downloadfilename.split("=")[-1]
+		    #	except:
+		    #		pass
+		    #else:
+		    #	downloadfilename = img_url.split("/")[-1]
+		    
+		    #urllib.request.urlretrieve(img_url, downloadcomicdir + downloadfilename)
+		    print("Downloading " + img_url + " as " + downloadfilename)
+		    filetosave = open(downloadcomicdir + downloadfilename, "wb")
+		    
+		    filetosave.write(requests.get(img_url, headers=notarobotheader).content)
+		    filetosave.close()
+	    
 		
 		#fetch the next page
 		current_page_url = cracker.findurl(pagefeed, comicdef["nextregex"], comicdef["rootcomicdir"])

--- a/jiminy.py
+++ b/jiminy.py
@@ -6,8 +6,7 @@ import datetime
 import zipfile
 import os
 def makecbz(comicname , downloaddir):
-	timedatestamp = str(datetime.datetime.now()).split(".")[0]
-	outputcbz = zipfile.ZipFile(downloaddir + "/" + comicname + " " +timedatestamp + ".cbz", 'w')
+	outputcbz = zipfile.ZipFile(downloaddir + "/" + comicname +".cbz", 'w')
 	comicdir = downloaddir + "/" + comicname + "/"
 	pagelist = os.listdir(comicdir)
 	try:

--- a/mrpeabody.py
+++ b/mrpeabody.py
@@ -2,7 +2,7 @@
 import os
 import sqlite3
 
-deflist = ["comicname" ,"starturl", "nextregex", "imageregex", "rootcomicdir", "useurlflag", "autonumber", "skip" ]
+deflist = ["comicname" ,"starturl", "nextregex", "imageregex", "rootcomicdir", "useurlflag", "autonumber", "skip"]
 
 def initdef(defdirectory):
 	comiclist =[]
@@ -69,7 +69,7 @@ def initdb(downloaddir, arg1, arg2):
 			exportlist = []
 			for i in deflist:
 				exportlist.append(comicdef[i])
-			db.execute("INSERT INTO  comicdef values (?,?,?,?,?,?,?)", exportlist) #INSERT THE VALUES
+			db.execute("INSERT INTO  comicdef values (?,?,?,?,?,?,?,?)", exportlist) #INSERT THE VALUES
 			conn.commit()
 			conn.close()
 		except Exception as e:

--- a/mrpeabody.py
+++ b/mrpeabody.py
@@ -73,7 +73,7 @@ def initdb(downloaddir, arg1, arg2):
 			conn.commit()
 			conn.close()
 		except Exception as e:
-			#print(e)
+			print(e)
 			pass
 		comiclist.append(comicdef["comicname"])
 	return comiclist

--- a/mrpeabody.py
+++ b/mrpeabody.py
@@ -2,7 +2,7 @@
 import os
 import sqlite3
 
-deflist = ["comicname" ,"starturl", "nextregex", "imageregex", "rootcomicdir", "useurlflag", "autonumber" ]
+deflist = ["comicname" ,"starturl", "nextregex", "imageregex", "rootcomicdir", "useurlflag", "autonumber", "skip" ]
 
 def initdef(defdirectory):
 	comiclist =[]


### PR DESCRIPTION
This requires a schema change in the sqlite files, and doesn't do anything to do so automatically (newly created ones are fine). It might make more sense to add code to turn that schema sideways into key-value pairs rather than horizontally like it is now.

This is needed for comics like Girl Genius that have event announcements interspersed as pages without comic images.

thoughts?